### PR TITLE
Add JsonIgnore annotation to product field in Review class

### DIFF
--- a/src/main/java/org/slayscale/Review.java
+++ b/src/main/java/org/slayscale/Review.java
@@ -10,6 +10,7 @@ public class Review {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore // avoid infinite recursion
     private Product product;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/slayscale/User.java
+++ b/src/main/java/org/slayscale/User.java
@@ -1,6 +1,5 @@
 package org.slayscale;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
@@ -16,7 +15,6 @@ public class User {
     private String username;
 
     @OneToMany(mappedBy = "author", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    @JsonIgnore
     private Set<Review> reviews;
 
     @ManyToMany(mappedBy = "following")


### PR DESCRIPTION
Lack of `@JsonIgnore` was causing an infinite loop.

### Testing

- Repeated the steps to reproduce the error described in [https://github.com/Aashna-Verma/SlayScale/issues/48](url) and observed the error doesn't happen anymore
- After repeating steps to reproduce error, I also verified `/api/users/1/reviews` and `/api/products` were still functioning as expected